### PR TITLE
Restrict bitstring to versions below 3.0.0

### DIFF
--- a/opam
+++ b/opam
@@ -16,6 +16,6 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "cryptokit"
-  "bitstring"
+  "bitstring" {< "3.0.0"}
 ]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
The newer ones removed the camlp4 syntax. The proper way to deal with it would be to migrate to the ppx variant but for now it is nice if the package just builds correctly.

Also reported to opam-repository: https://github.com/ocaml/opam-repository/pull/11233